### PR TITLE
Add network validation to CreateCAT component for supported chains

### DIFF
--- a/web/src/app/create/page.tsx
+++ b/web/src/app/create/page.tsx
@@ -67,7 +67,6 @@ const fields = [
     description: "Maximum percentage the supply can expand (1-100)",
   },
 ];
-const SUPPORTED_CHAINS = [534351, 137, 1, 6119];
 export default function CreateCAT() {
   const [formData, setFormData] = useState<DeployContractProps>({
     tokenName: "",
@@ -192,11 +191,11 @@ export default function CreateCAT() {
                     }
                   />{" "}
                 </motion.div>
-              ) : chainId && !SUPPORTED_CHAINS.includes(chainId) ? (
+              ) : chainId && !ClowderVaultFactories[chainId] ? (
                 <div className="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-6">
-                  <p>⚠ Unsupported network detected.</p>
+                  <p>⚠ Please switch to a supported network.</p>
                   <p>
-                    Please switch to a supported network or contact us on{" "}
+                    If you would like support for another network, contact us on{" "}
                     <a
                       href="https://discord.com/invite/fuuWX4AbJt"
                       target="_blank"

--- a/web/src/app/create/page.tsx
+++ b/web/src/app/create/page.tsx
@@ -22,7 +22,6 @@ import {
 } from "@/components/ui/card";
 import { Info, Loader2 } from "lucide-react";
 import { motion } from "framer-motion";
-
 interface DeployContractProps {
   tokenName: string;
   tokenSymbol: string;
@@ -68,7 +67,7 @@ const fields = [
     description: "Maximum percentage the supply can expand (1-100)",
   },
 ];
-
+const SUPPORTED_CHAINS = [534351, 137, 1, 6119];
 export default function CreateCAT() {
   const [formData, setFormData] = useState<DeployContractProps>({
     tokenName: "",
@@ -79,7 +78,7 @@ export default function CreateCAT() {
   });
   const [isDeploying, setIsDeploying] = useState(false);
 
-  const { address } = useAccount();
+  const { address, chainId } = useAccount();
   const router = useRouter();
 
   const getTransactionHistory = () => {
@@ -186,9 +185,29 @@ export default function CreateCAT() {
                     Connect your wallet to create a new CAT
                   </p>
                   <ConnectButton
-                    label={<span className="text-black dark:text-white">Connect Wallet</span>}
+                    label={
+                      <span className="text-black dark:text-white">
+                        Connect Wallet
+                      </span>
+                    }
                   />{" "}
                 </motion.div>
+              ) : chainId && !SUPPORTED_CHAINS.includes(chainId) ? (
+                <div className="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-6">
+                  <p>⚠ Unsupported network detected.</p>
+                  <p>
+                    Please switch to a supported network or contact us on{" "}
+                    <a
+                      href="https://discord.com/invite/fuuWX4AbJt"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 cursor-pointer hover:underline"
+                    >
+                      Discord
+                    </a>
+                    .
+                  </p>
+                </div>
               ) : (
                 <form onSubmit={handleSubmit} className="space-y-6">
                   {fields.map(

--- a/web/src/app/my-cats/page.tsx
+++ b/web/src/app/my-cats/page.tsx
@@ -127,7 +127,7 @@ export default function MyCATsPage() {
     if (address) {
       fetchCATsFromAllChains();
     }
-  }, [address, fetchCATsFromAllChains]);
+  }, [address]);
 
   return (
     <Layout>


### PR DESCRIPTION
1. Added validation to ensure users are on a supported network before deploying a Contribution Accounting Token (CAT).
2. Displays an error message if the user is on an unsupported network.
3. Added a Discord support link (https://discord.com/invite/fuuWX4AbJt) for users needing assistance.
4. Remove unnecessary dependency from useEffect in MyCATsPage

![Screenshot (115)](https://github.com/user-attachments/assets/d35fc17c-7b86-4579-95db-2119f83de6a1)
